### PR TITLE
Adding room discover to fix #3

### DIFF
--- a/src/Discover.svelte
+++ b/src/Discover.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte"
+  import { svelteStore, connectRoom, GameState } from "./lib/synced-store"
+
+  import NavBar from "./NavBar.svelte"
+
+  export let roomId = [
+    { id: "2RiDxgedP3wXEi2eCs2ci" },
+    { id: "Poe1gedP3wXEi2eCs8hrt" },
+  ]
+  export let createRoom: boolean
+
+  $: gameState = $svelteStore.gameData.state || GameState.Waiting
+
+  let enteredRoom = false
+
+  function enter(index) {
+    enteredRoom = true
+    window.location.hash = `#/rooms/${index}`
+  }
+</script>
+
+<main class="grid h-screen place-items-center">
+  <NavBar />
+  {#if gameState === GameState.Waiting}
+    <div class="flex flex-col">
+      <h1 class="text-6xl font-bold font-ubuntu text-blue-500">
+        Room Discovery
+      </h1>
+      <p class="text-md font-bold text-blue-400 font-ubuntu">Click to join !</p>
+    </div>
+    <div
+      class="flex flex-col md:flex-row flex-wrap gap-4"
+      style="max-width: 70vw"
+    >
+      {#each roomId as room}
+        <div
+          on:click={enter(room.id)}
+          class="text-2xl font-bold font-ubuntu text-white bg-gradient-to-r from-blue-500 to-violet-500 rounded-lg px-4 py-2 shadow-lg active:scale-90 duration-200"
+        >
+          <p>{room.id}</p>
+        </div>
+      {/each}
+    </div>
+  {/if}
+  <div
+    class="flex {enteredRoom
+      ? 'flex-col md:flex-row'
+      : 'flex-col'} items-center gap-6"
+  />
+</main>
+
+<style>
+  :root {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+      Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  }
+
+  main {
+    text-align: center;
+    padding: 1em;
+    margin: 0 auto;
+  }
+
+  img {
+    height: 16rem;
+    width: 16rem;
+  }
+
+  p {
+    max-width: 14rem;
+    margin: 1rem auto;
+    line-height: 1.35;
+  }
+
+  @media (min-width: 480px) {
+    h1 {
+      max-width: none;
+    }
+
+    p {
+      max-width: none;
+    }
+  }
+</style>

--- a/src/Discover.svelte
+++ b/src/Discover.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-  import { onMount, onDestroy } from "svelte"
-  import { svelteStore, connectRoom, GameState } from "./lib/synced-store"
+  import { svelteStore, GameState } from "./lib/synced-store"
 
   import NavBar from "./NavBar.svelte"
+  import { store } from "./lib/synced-store"
 
   export let roomId = [
     { id: "2RiDxgedP3wXEi2eCs2ci" },
     { id: "Poe1gedP3wXEi2eCs8hrt" },
   ]
   export let createRoom: boolean
-
+  const playerCount = store.players.length
   $: gameState = $svelteStore.gameData.state || GameState.Waiting
 
   let enteredRoom = false
@@ -39,6 +39,7 @@
           class="text-2xl font-bold font-ubuntu text-white bg-gradient-to-r from-blue-500 to-violet-500 rounded-lg px-4 py-2 shadow-lg active:scale-90 duration-200"
         >
           <p>{room.id}</p>
+          <p class="text-base">{playerCount} players</p>
         </div>
       {/each}
     </div>

--- a/src/Home.svelte
+++ b/src/Home.svelte
@@ -4,6 +4,7 @@
   import Room from "./Room.svelte"
   import url from "./lib/url"
   import NavBar from "./NavBar.svelte"
+  import Discover from "./Discover.svelte"
 
   $: roomFragment = $url.hash.split(["#/rooms/"])[1]
   $: roomId = roomFragment?.split("/")[0]
@@ -14,6 +15,10 @@
     window.location.hash = `#/rooms/${newRoomId}/create`
   }
 
+  function discoverRoom() {
+    window.location.hash = `#/rooms/discovery`
+  }
+
   function joinRoom() {
     if (!roomId) {
       return alert("Invalid room ID")
@@ -22,7 +27,9 @@
   }
 </script>
 
-{#if $url.hash.indexOf("#/rooms/") === 0 || $url.hash === "#/"}
+{#if $url.hash.indexOf("#/rooms/discovery") === 0}
+  <Discover />
+{:else if $url.hash.indexOf("#/rooms/") === 0 || $url.hash === "#/"}
   <Room {roomId} {createRoom} />
 {:else}
   <main class="grid h-screen place-items-center">
@@ -44,10 +51,18 @@
             on:click={joinRoom}>JOIN</button
           >
         </div>
-        <button
-          class="w-full rounded-lg bg-gradient-to-r from-blue-500 to-violet-500 text-white font-bold font-ubuntu px-4 py-2 tracking-widest active:scale-90 duration-200"
-          on:click={createNewRoom}>CREATE NEW ROOM</button
-        >
+        <div class="flex flex-row gap-2">
+          <button
+            class="w-full rounded-lg bg-gradient-to-r from-blue-500 to-violet-500 text-white font-bold font-ubuntu px-4 py-2 tracking-widest active:scale-90 duration-200"
+            on:click={discoverRoom}
+          >
+            ROOM DISCOVERY
+          </button>
+          <button
+            class="w-full rounded-lg bg-gradient-to-r from-blue-500 to-violet-500 text-white font-bold font-ubuntu px-4 py-2 tracking-widest active:scale-90 duration-200"
+            on:click={createNewRoom}>CREATE NEW ROOM</button
+          >
+        </div>
       </div>
     </div>
   </main>

--- a/src/WaitingRoom.svelte
+++ b/src/WaitingRoom.svelte
@@ -66,7 +66,7 @@
 <div class="flex flex-col">
   <div class="grid place-items-center">
     <div class="flex flex-col gap-6">
-      <h2 class="text-4xl font-ubuntu text-blue-500 font-bold">
+      <h2 class="text-xl px-12 font-ubuntu text-blue-500 font-bold">
         ⚙ Preferences
       </h2>
       <div class="flex flex-col gap-3">


### PR DESCRIPTION
## **According to this issue, I'm interested in doing this so here it is!**

### Adding a room discovery button to home page
![image](https://user-images.githubusercontent.com/74261236/157721201-4ff14ecf-d114-4c82-8cfa-a30f45fc3035.png)

### Room discovery page
![image](https://user-images.githubusercontent.com/74261236/157721272-8a8cc71f-6e21-4f1d-8eac-4d509200d50b.png)

####   `[PLEASE READ]`   As I don't know how to retrieve actual data for this issue, I just created mocking data to test. I believe it would be entirely functioning if you could put the real data into the value I assign.

### Reroute to `/{room.id}`
![image](https://user-images.githubusercontent.com/74261236/157721329-d42118a9-9c14-4023-88dd-22f9ab142252.png)
<br>

### How to test
0: Pull source code from [here ](https://github.com/santhitak/that-paper-game) to test before merge request.
1: Create a room and put room id in **Discovery.svelte** `room ID value`
2: Open [the-paper-game](http://localhost:3000/) in new tab(e.g. incognito tab) then click on **room discovery button**
3: You will see it appear on the page, click on the room id and it will reroute to your existing room.


## `Feel free to ask questions or give some suggestions, I'm very comfortable fixing or changing anything. Thank you!`

<br><br>